### PR TITLE
Added aria live region for accessibility

### DIFF
--- a/live-comment-preview.php
+++ b/live-comment-preview.php
@@ -112,8 +112,9 @@ function lcp_output_js() {
 				<li id="comment-preview">
 					<img src="' . $avatar_default . '" alt="" class="avatar avatar-' . $avatar_size . '" width="' . $avatar_size . '" height="' . $avatar_size . '"/>
 					<cite>COMMENT_AUTHOR</cite> Says:
-					<br />
+					<div aria-live="polite">
 					COMMENT_CONTENT
+					</div>
 				</li>
 			</ol>';
 	}


### PR DESCRIPTION
I use this plugin on my blog (www.brucelawson.co.uk) - thanks! - and a
blind screenreader user who left a comment emailed me to suggest that
the comment preview be wrapped in an aria live region so that his
screenreader could be alerted that something had changed.
